### PR TITLE
Bug-fix

### DIFF
--- a/scss/home/elements.scss
+++ b/scss/home/elements.scss
@@ -14,6 +14,7 @@
       bottom: 0;
       right: 0px;
       left: auto;
+      width: 20%;
 
       @media screen and (max-width: $small-breakpoint) {
           width: 18%;


### PR DESCRIPTION
Occasionally, the cornerelement will overlap the Android playstore button, and prevent clicks.
